### PR TITLE
feat: modify cloudfront OAC bucket policy only allow traffic from HTTPS sources

### DIFF
--- a/cloudfront-access.tf
+++ b/cloudfront-access.tf
@@ -73,6 +73,8 @@ resource "aws_s3_bucket_policy" "s3_cloudfront_oac" {
 ## s3 cloudfront policy document for origin access control
 data "aws_iam_policy_document" "s3_cloudfront_oac" {
   count = var.origin_access_control ? 1 : 0
+
+  ## ClourFront OAC
   statement {
     sid    = "AllowCloudfrontToListBucket"
     effect = "Allow"
@@ -126,6 +128,29 @@ data "aws_iam_policy_document" "s3_cloudfront_oac" {
       values = [
         var.cloudfront_arn
       ]
+    }
+  }
+
+  ## Allow only HTTPS requests to bucket
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.s3.arn,
+      "${aws_s3_bucket.s3.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
     }
   }
 }

--- a/cloudfront-access.tf
+++ b/cloudfront-access.tf
@@ -131,9 +131,9 @@ data "aws_iam_policy_document" "s3_cloudfront_oac" {
     }
   }
 
-  ## Allow only HTTPS requests to bucket
+  ## Deny all HTTP requests
   statement {
-    sid    = "AllowSSLRequestsOnly"
+    sid    = "BlockHTTPRequests"
     effect = "Deny"
 
     principals {


### PR DESCRIPTION
If CloudFront OAC is defined, only HTTPS traffic should be allowed from anywhere to the S3