### PR TITLE
Fix: terraform plan error for bucket policy due to count

### DIFF
--- a/bucket-policy.tf
+++ b/bucket-policy.tf
@@ -1,14 +1,17 @@
 ## s3 cloudfront policy for origin access control
 resource "aws_s3_bucket_policy" "bucket_policy" {
-  count = (var.origin_access_control || var.block_http_request || var.bucket_policy) != null ? 1 : 0
+  count = (var.origin_access_control || var.block_http_request || var.bucket_policy != null) ? 1 : 0
 
   bucket = aws_s3_bucket.s3.id
 
-  policy = jsonencode(compact([
-    var.origin_access_control ? data.aws_iam_policy_document.s3_cloudfront_oac[0].json : "",
-    var.block_http_request ? data.aws_iam_policy_document.block_http_request[0].json : "",
-    var.bucket_policy != null ? var.bucket_policy : ""
-  ]))
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      var.origin_access_control ? jsondecode(data.aws_iam_policy_document.s3_cloudfront_oac[0].json).Statement : [],
+      var.block_http_request ? jsondecode(data.aws_iam_policy_document.block_http_request[0].json).Statement : [],
+      var.bucket_policy != null ? jsondecode(var.bucket_policy).Statement : []
+    )
+  })
 }
 
 ## s3 cloudfront policy document for origin access control

--- a/bucket-policy.tf
+++ b/bucket-policy.tf
@@ -1,18 +1,14 @@
 ## s3 cloudfront policy for origin access control
 resource "aws_s3_bucket_policy" "bucket_policy" {
-  count  = var.origin_access_control || var.block_http_request || var.bucket_policy != null ? 1 : 0
+  count = (var.origin_access_control || var.block_http_request || var.bucket_policy) != null ? 1 : 0
+
   bucket = aws_s3_bucket.s3.id
-  policy = data.aws_iam_policy_document.combined[0].json
-}
 
-data "aws_iam_policy_document" "combined" {
-  count = var.origin_access_control || var.block_http_request || var.bucket_policy != null ? 1 : 0
-
-  source_policy_documents = compact([
+  policy = jsonencode(compact([
     var.origin_access_control ? data.aws_iam_policy_document.s3_cloudfront_oac[0].json : "",
     var.block_http_request ? data.aws_iam_policy_document.block_http_request[0].json : "",
     var.bucket_policy != null ? var.bucket_policy : ""
-  ])
+  ]))
 }
 
 ## s3 cloudfront policy document for origin access control


### PR DESCRIPTION
- Because of the Count condition in Bucket policy, the Terraform plan was giving the error
- Replace the inline implementation for the concatenation of JSON policies with a dedicated data source block